### PR TITLE
configure: fix ffs check with _GNU_SOURCE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -484,7 +484,8 @@ AC_CHECK_DECL([mach_absolute_time],
 AC_CHECK_DECLS([__builtin_ctz])
 
 AC_CHECK_DECLS([ffs], [], [],
-  [[#include <strings.h>]])
+  [[#define _GNU_SOURCE
+#include <strings.h>]])
 
 AC_CHECK_DECLS([be64toh, betoh64, bswap64, __builtin_bswap64], [], [],
   [[#if defined(HAVE_ENDIAN_H)


### PR DESCRIPTION
According to the man page, ffs requires this or others to be defined.
_GNU_SOURCE tends to be inclusive so use that for simplicity.